### PR TITLE
Call `rowAction` if it exists

### DIFF
--- a/addon/components/fabulous-table.js
+++ b/addon/components/fabulous-table.js
@@ -96,7 +96,7 @@ export default Ember.Component.extend({
          * @return {undefined}
          */
         rowClicked(item) {
-            this.rowAction(item);
+            this.rowAction && this.rowAction(item);
         },
         
         /**


### PR DESCRIPTION
`rowAction` was required. Now it's not.